### PR TITLE
Adding new dynamic sender implementation

### DIFF
--- a/src/Core/AzureServiceBusWorkerRegister.cs
+++ b/src/Core/AzureServiceBusWorkerRegister.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace MinimalAzureServiceBus.Core
 {
@@ -7,10 +6,9 @@ namespace MinimalAzureServiceBus.Core
     {
         public static AzureServiceBusWorkerRegistration RegisterAzureServiceBusWorker(this IServiceCollection services, string ServiceBusConnectionString, string appName)
         {
-            var registration = new AzureServiceBusWorkerRegistrationDetail(ServiceBusConnectionString, appName);
+            var registration = new AzureServiceBusWorkerRegistrationDetail(ServiceBusConnectionString, appName, services);
 
             services.AddSingleton(registration);
-            services.AddScoped<IMessageSender>(sp => new MessageSender(ServiceBusConnectionString, sp.GetRequiredService<ILogger<MessageSender>>()));
             services.AddHostedService<AzureServiceBusWorker>();
 
             return registration;

--- a/src/Core/AzureServiceBusWorkerRegistrationDetail.cs
+++ b/src/Core/AzureServiceBusWorkerRegistrationDetail.cs
@@ -1,13 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 using MinimalAzureServiceBus.Core.Models;
 
 namespace MinimalAzureServiceBus.Core
 {
     public class AzureServiceBusWorkerRegistrationDetail : AzureServiceBusWorkerRegistration
     {
-        public AzureServiceBusWorkerRegistrationDetail(string serviceBusConnectionString, string appName) : base(serviceBusConnectionString, appName)
+
+        public AzureServiceBusWorkerRegistrationDetail(string serviceBusConnectionString, string appName, IServiceCollection services) : base(serviceBusConnectionString, appName, services)
         {
+
         }
 
         internal ErrorHandlingConfiguration ErrorHandlingConfiguration => _errorHandlingConfiguration;

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -7,10 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.4" />
+    <PackageReference Include="Castle.Core" Version="5.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
   </ItemGroup>
 
 	<PropertyGroup>

--- a/src/Core/DynamicSender/SenderInterceptor.cs
+++ b/src/Core/DynamicSender/SenderInterceptor.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using Castle.DynamicProxy;
+using Microsoft.Extensions.Logging;
+using MinimalAzureServiceBus.Core.Models;
+
+namespace MinimalAzureServiceBus.Core.DynamicSender
+{
+    internal class SenderInterceptor : IInterceptor, IDisposable
+    {
+        private readonly MessageSender _messageSender;
+
+        internal SenderInterceptor(string connectionString, ILoggerFactory loggerFactory) => 
+            _messageSender = new MessageSender(connectionString, loggerFactory.CreateLogger<MessageSender>());
+
+        public void Intercept(IInvocation invocation)
+        {
+            if (invocation.Method.ReturnType != typeof(Task) || (invocation.Method.ReturnType.IsGenericType && invocation.Method.ReturnType.GetGenericTypeDefinition() != typeof(Task<>)))
+                throw new InvalidOperationException("Only methods that return Task are supported");
+
+            if (invocation.Arguments.Length > 1)
+                throw new InvalidOperationException("Only one argument is allowed and that argument will be used for the body of the message");
+
+            var methodName = invocation.Method.Name;
+            var messageType = ServiceBusType.Unknown;
+            var name = string.Empty;
+
+            if (invocation.Method.GetCustomAttribute(inherit: true, attributeType:typeof(MessagingAttribute)) is MessagingAttribute messagingAttribute)
+            {
+                name = string.IsNullOrEmpty(messagingAttribute.Name) ? methodName : messagingAttribute.Name;
+                messageType = messagingAttribute switch
+                {
+                    QueueAttribute _ => ServiceBusType.Queue,
+                    TopicAttribute _ => ServiceBusType.Topic,
+                    _ => messageType
+                };
+            }
+            else
+            {
+                if (methodName.StartsWith("Send", StringComparison.OrdinalIgnoreCase))
+                    (messageType, name) = (ServiceBusType.Queue, methodName[4..]);
+                else if (methodName.StartsWith("Publish"))
+                    (messageType, name) = (ServiceBusType.Topic, methodName[7..]);
+            }
+
+            var parameterType = invocation.Method.GetParameters().First().ParameterType;
+            var body = JsonSerializer.Serialize(invocation.Arguments[0], parameterType);
+            var message = new ServiceBusMessage { Body = BinaryData.FromString(body) };
+            var dispatch = messageType switch
+            {
+                ServiceBusType.Queue => _messageSender.SendAsync(name, message),
+                ServiceBusType.Topic => _messageSender.PublishAsync(name, message),
+                _ => Task.CompletedTask
+            };
+
+            invocation.ReturnValue = dispatch;
+        }
+
+        public void Dispose()
+        {
+            // TODO release managed resources here
+        }
+    }
+}

--- a/src/Core/MessagingAttribute.cs
+++ b/src/Core/MessagingAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace MinimalAzureServiceBus.Core
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public abstract class MessagingAttribute : Attribute
+    {
+        public string Name { get; }
+
+        protected MessagingAttribute(string name = "") => Name = name;
+    }
+}

--- a/src/Core/Models/ServiceBusType.cs
+++ b/src/Core/Models/ServiceBusType.cs
@@ -1,0 +1,9 @@
+﻿namespace MinimalAzureServiceBus.Core.Models
+{
+    public enum ServiceBusType
+    {
+        Unknown,
+        Queue,
+        Topic
+    }
+}

--- a/src/Core/QueueAttribute.cs
+++ b/src/Core/QueueAttribute.cs
@@ -1,0 +1,7 @@
+﻿namespace MinimalAzureServiceBus.Core
+{
+    public class QueueAttribute : MessagingAttribute
+    {
+        public QueueAttribute(string queueName = "") : base(queueName) { }
+    }
+}

--- a/src/Core/TopicAttribute.cs
+++ b/src/Core/TopicAttribute.cs
@@ -1,0 +1,7 @@
+﻿namespace MinimalAzureServiceBus.Core
+{
+    public class TopicAttribute : MessagingAttribute
+    {
+        public TopicAttribute(string topicName = "") : base(topicName) { }
+    }
+}


### PR DESCRIPTION
instead of using an `IMessageSender` users can now create their own strongly typed interface and register it as a sender.

This helps enable the ability to have multiple workers for multiple ASB namespaces

relates to https://github.com/DeepForgeTech/MinimalAzureServiceBus/issues/9